### PR TITLE
fix "batch requests are disabled"

### DIFF
--- a/config/node/config.toml
+++ b/config/node/config.toml
@@ -71,6 +71,7 @@ WriteTimeout = "60s"
 MaxRequestsPerIPAndSecond = 5000
 SequencerNodeURI = ""
 EnableL2SuggestedGasPricePolling = true
+BatchRequestsEnabled = true
 	[RPC.WebSockets]
 		Enabled = true
 		Port = 8133


### PR DESCRIPTION
## Problem

I was testing the [quickstart](https://docs.polygon.technology/cdk/get-started/quickstart-validium/) and saw L2 tx went through in my Metamask. However, it doesn't show up in the explorer

## Root cause analysis

```
zkevm-explorer-l2  |   request:
zkevm-explorer-l2  | 
zkevm-explorer-l2  |     url: http://zkevm-explorer-json-rpc:8124
zkevm-explorer-l2  | 
zkevm-explorer-l2  |     body: [{"id":0,"jsonrpc":"2.0","method":"eth_getBlockByNumber","params":["0x2",true]},{"id":1,"jsonrpc":"2.0","method":"eth_getBlockByNumber","params":["0x1",true]},{"id":2,"jsonrpc":"2.0","method":"eth_getBlockByNumber","params":["0x0",true]}]
zkevm-explorer-l2  | 
zkevm-explorer-l2  |   response:
zkevm-explorer-l2  | 
zkevm-explorer-l2  |     status code: 400
zkevm-explorer-l2  | 
zkevm-explorer-l2  |     body: batch requests are disabled
...
```

