### PR TITLE
Compatibility with Docker-compose v2.24

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -198,7 +198,7 @@ services:
       file: ./services/docker-compose-explorer-backend.yml
       service: explorer-backend
     container_name: explorer-backend-l1
-    image: blockscout/blockscout:${EXPLORER_DOCKER_TAG_L1_BACKEND:-master}
+    image: blockscout/blockscout:${EXPLORER_DOCKER_TAG_L1_BACKEND:-latest}
     ports:
       - 4000:4000
     environment:

--- a/services/docker-compose-explorer-sig-provider.yml
+++ b/services/docker-compose-explorer-sig-provider.yml
@@ -14,4 +14,5 @@ services:
     restart: always
     container_name: 'explorer-sig-provider'
     ports:
-      - 8151:8050
+      - target: 8050
+        published: 8151

--- a/services/docker-compose-explorer-smart-contract-verifier.yml
+++ b/services/docker-compose-explorer-smart-contract-verifier.yml
@@ -10,4 +10,5 @@ services:
     env_file:
       -  ../envs/common-smart-contract-verifier.env
     ports:
-      - 8150:8050
+      - target: 8050
+        published: 8150

--- a/services/docker-compose-explorer-visualizer.yml
+++ b/services/docker-compose-explorer-visualizer.yml
@@ -18,4 +18,5 @@ services:
     env_file:
       -  ../envs/common-visualizer.env
     ports:
-      - 8152:8050
+      - target: 8050
+        published: 8152


### PR DESCRIPTION
Running `docker-compose up` on version of compose `2.24.0` causes these errors:
```
service ports services.explorer-visualizer.ports.[0] is missing a target port
service ports services.explorer-smart-contract-verifier.ports.[0] is missing a target port
service ports services.explorer-sig-provider.ports.[1] is missing a target port
```

This PR fixes the problem.

In addition, I'd suggest switching from master (unstable) to latest (stable) tag for blockscout/blockscout image.