### PR TITLE
fix visualizer proxy CORS setup

### DIFF
--- a/proxy/visualizer.conf.template
+++ b/proxy/visualizer.conf.template
@@ -4,13 +4,19 @@ map $http_upgrade $connection_upgrade {
   ''      close;
 }
 
+map $http_origin $allowed_origin {
+    ~^${PROXIED_FRONT_URL}(:[0-9]+)?$ $http_origin;
+    # NGINX won't set empty string headers, so if no match, header is unset.
+    default '';
+}
+
 server {
     listen       8081;
     server_name  explorer-visualizer;
     proxy_http_version 1.1;
     proxy_hide_header Access-Control-Allow-Origin;
     proxy_hide_header Access-Control-Allow-Methods;
-    add_header 'Access-Control-Allow-Origin' '${PROXIED_FRONT_URL}' always;
+    add_header 'Access-Control-Allow-Origin' $allowed_origin always;
     add_header 'Access-Control-Allow-Credentials' 'true' always;
     add_header 'Access-Control-Allow-Methods' 'PUT, GET, POST, OPTIONS, DELETE, PATCH' always;
     add_header 'Access-Control-Allow-Headers' 'DNT,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Range,Authorization,x-csrf-token' always;
@@ -30,7 +36,7 @@ server {
         proxy_set_header      Connection $connection_upgrade;
         proxy_cache_bypass    $http_upgrade;
         if ($request_method = 'OPTIONS') {
-            add_header 'Access-Control-Allow-Origin' '${PROXIED_FRONT_URL}' always;
+            add_header 'Access-Control-Allow-Origin' $allowed_origin always;
             add_header 'Access-Control-Allow-Credentials' 'true' always;
             add_header 'Access-Control-Allow-Methods' 'PUT, GET, POST, OPTIONS, DELETE, PATCH' always;
             add_header 'Access-Control-Allow-Headers' 'DNT,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Range,Authorization,x-csrf-token' always;

--- a/services/docker-compose-explorer-nginx.yml
+++ b/services/docker-compose-explorer-nginx.yml
@@ -12,3 +12,5 @@ services:
     container_name: visualizer-proxy
     volumes:
       - "../proxy/visualizer.conf.template:/etc/nginx/templates/default.conf.template"
+    environment:
+      - NGINX_CONFIG_VERSION=1


### PR DESCRIPTION
the visualizer micro-service only works for L2 explorer but not the L1 explorer (i.e. 500 error)

in console logs, there is 

> Access to fetch at 'http://localhost:8083/api/v1/solidity:visualize-contracts' from origin 'http://localhost:81' has been blocked by CORS policy: Response to preflight request doesn't pass access control check: The 'Access-Control-Allow-Origin' header has a value 'http://localhost' that is not equal to the supplied origin. 

since the request can come from either L1 or L2 explorer's origin. we need to support both.

per [Access-Control-Allow-Origin](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Allow-Origin) doc,

> Only a single origin can be specified. If the server supports clients from multiple origins, it must return the origin for the specific client making the request.

a few solutions are defined [here](https://stackoverflow.com/questions/36582199/how-to-allow-access-via-cors-to-multiple-domains-within-nginx)

it's worthing that the `if` solution doesn't work. we have to use `map`

basically the idea is using regex to match the domain url with any ports and returns the same origin from the client making the request