### PR TITLE
Disable internal transactions fetcher on l2 explorer

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -328,6 +328,7 @@ services:
       - SECRET_KEY_BASE=${EXPLORER_L2_SECRET_KEY_BASE}
       - MIX_ENV=prod
       - INDEXER_ZKEVM_BATCHES_ENABLED=true
+      - INDEXER_DISABLE_INTERNAL_TRANSACTIONS_FETCHER=true
       - CHAIN_TYPE=polygon_zkevm
 
   zkevm-explorer-json-rpc:


### PR DESCRIPTION
The fix made to resolve this issue https://github.com/blockscout/blockscout/issues/9237

seems, l2 rpc doesn't support `debug_traceTransaction` method:
```
curl -X POST \
  -H "Content-Type: application/json" \
  --data '{"method":"debug_traceTransaction","params":["0x01c2954aa10272d9617d8d0b2f3629babe7dd373ea3f1d072c7e8618d1f215a0"],"id":1,"jsonrpc":"2.0"}' http://localhost:8123

{"jsonrpc":"2.0","id":1,"error":{"code":-32601,"message":"the method debug_traceTransaction does not exist/is not available"}}
```

Thus, we have to switch off internal transactions fetcher.