### PR TITLE
Set ETHEREUM_JSONRPC_TRACE_URL to l2 RPC endpoint

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -324,6 +324,7 @@ services:
       - NETWORK=POE
       - SUBNETWORK=Polygon Hermez
       - ETHEREUM_JSONRPC_HTTP_URL=http://zkevm-explorer-json-rpc:8124
+      - ETHEREUM_JSONRPC_TRACE_URL=http://zkevm-explorer-json-rpc:8124
       - DATABASE_URL=postgres://l2_explorer_user:l2_explorer_password@explorer-backend-l2-db:5432/l2_explorer_db
       - SECRET_KEY_BASE=${EXPLORER_L2_SECRET_KEY_BASE}
       - MIX_ENV=prod


### PR DESCRIPTION
Closes https://github.com/Snapchain/zkValidium-quickstart/pull/37
Related to https://github.com/blockscout/blockscout/issues/9237

Currently is retrieved from common-blockscout.env which is set to l1 RPC endpoint.

We need to override `ETHEREUM_JSONRPC_TRACE_URL` to l2 RPC endpoint in the main config.